### PR TITLE
Drop 3.6 support, do Docker-based dev setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/python:3.9.4
+FROM circleci/python:3.10.1
 
 # Install git 2.22 from source
 RUN sudo apt-get update
@@ -12,28 +12,42 @@ RUN cd /usr/src/ && \
     sudo make clean && \
     sudo rm -r /usr/src/git*
 
-# Pipx
-ENV PATH=/home/circleci/.local/bin:$PATH
-RUN pip install --user pipx
-RUN pipx install poetry
+# Poetry
+RUN sudo curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
 
-# Python 3.6.13
-RUN sudo curl -O https://www.python.org/ftp/python/3.6.13/Python-3.6.13.tgz
-RUN sudo tar -xvzf Python-3.6.13.tgz
-RUN cd Python-3.6.13 && sudo ./configure --prefix=/usr/
-RUN cd Python-3.6.13 && sudo make
-RUN cd Python-3.6.13 && sudo make install
+# Python 3.7.12
+RUN sudo curl -O https://www.python.org/ftp/python/3.7.12/Python-3.7.12.tgz && \
+    sudo tar -xvzf Python-3.7.12.tgz && \
+    cd Python-3.7.12 && \
+    sudo ./configure --prefix=/usr/ && \
+    sudo make && \
+    sudo make install && \
+    sudo make clean && \
+    cd .. && \
+    sudo rm -r Python-3.7.12
 
-# Python 3.7.10
-RUN sudo curl -O https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz
-RUN sudo tar -xvzf Python-3.7.10.tgz
-RUN cd Python-3.7.10 && sudo ./configure --prefix=/usr/
-RUN cd Python-3.7.10 && sudo make
-RUN cd Python-3.7.10 && sudo make install
+# Python 3.8.11
+RUN sudo curl -O https://www.python.org/ftp/python/3.8.11/Python-3.8.11.tgz && \
+    sudo tar -xvzf Python-3.8.11.tgz && \
+    cd Python-3.8.11 && \
+    sudo ./configure --prefix=/usr/ && \
+    sudo make && \
+    sudo make install && \
+    sudo make clean && \
+    cd .. && \
+    sudo rm -r Python-3.8.11
 
-# Python 3.8.10
-RUN sudo curl -O https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz
-RUN sudo tar -xvzf Python-3.8.10.tgz
-RUN cd Python-3.8.10 && sudo ./configure --prefix=/usr/
-RUN cd Python-3.8.10 && sudo make
-RUN cd Python-3.8.10 && sudo make install
+# Python 3.9.10
+RUN sudo curl -O https://www.python.org/ftp/python/3.9.10/Python-3.9.10.tgz && \
+    sudo tar -xvzf Python-3.9.10.tgz && \
+    cd Python-3.9.10 && \
+    sudo ./configure --prefix=/usr/ && \
+    sudo make && \
+    sudo make install && \
+    sudo make clean && \
+    cd .. && \
+    sudo rm -r Python-3.9.10
+
+RUN sudo mkdir /code
+WORKDIR /code
+RUN poetry config virtualenvs.in-project true

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -210,9 +210,7 @@ def github_add_collaborators(
 
     github_client = GithubClient()
     collaborators_api = f'/teams/{team_id}/repos/{GITHUB_ORG_NAME}/{repo_name}'
-    github_client.put(
-        collaborators_api, json={'permission': permission}
-    )
+    github_client.put(collaborators_api, json={'permission': permission})
 
     return True
 
@@ -313,9 +311,10 @@ def circleci_configure_project_settings(repo_name):
         json={
             'feature_flags': {
                 'build-prs-only': True,
-                'autocancel-builds': True
+                'autocancel-builds': True,
             }
-        })
+        },
+    )
     resp.raise_for_status()
 
 
@@ -361,11 +360,11 @@ def temple_setup():
                     'ci/circleci: lint',
                     'ci/circleci: test',
                 ],
-                'strict': True
+                'strict': True,
             },
             'enforce_admins': False,
-            'restrictions': None
-        }
+            'restrictions': None,
+        },
     )
 
     print('Following the project on CircleCI.')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
 line-length = 79
-target-version = ['py36']
+target-version = ['py37']
 skip-string-normalization = true
 

--- a/{{cookiecutter.repo_name}}/.circleci/config.yml
+++ b/{{cookiecutter.repo_name}}/.circleci/config.yml
@@ -5,6 +5,9 @@ executors:
     working_directory: ~/{{cookiecutter.repo_name}}
     docker:
       - image: opus10/circleci-public-python-library
+        environment:
+          # Ensure makefile commands are not wrapped in "docker run"
+          MAKE_CMD_WRAPPER: ''
 
 {% raw -%}
 jobs:
@@ -14,14 +17,14 @@ jobs:
       - checkout
       - restore_cache:
           key: v1-{{ checksum "poetry.lock" }}
-      - run: make ci_setup
-      - run: make test
+      - run: make dependencies
+      - run: make full-test-suite
       - save_cache:
           key: v1-{{ checksum "poetry.lock" }}
           paths:
             - /home/circleci/.local
             - /home/circleci/.cache/pypoetry/virtualenvs
-            - /home/circleci/.cache/pipx
+            - /home/circleci/{% endraw -%}{{cookiecutter.repo_name}}{% raw -%}/.venv
             - /home/circleci/{% endraw -%}{{cookiecutter.repo_name}}{% raw -%}/.tox
 
   lint:
@@ -30,17 +33,18 @@ jobs:
       - checkout
       - restore_cache:
           key: v1-{{ checksum "poetry.lock" }}
-      - run: make ci_setup
+      - run: make dependencies
       - run: make lint
 
-  check_changelog:
+  check_commits:
     executor: python
     steps:
       - checkout
       - restore_cache:
           key: v1-{{ checksum "poetry.lock" }}
-      - run: make ci_setup
-      - run: make check_changelog
+      - run: make dependencies
+      - run: poetry run git tidy-log origin/master..
+      - run: make tidy-lint
 
   deploy:
     executor: python
@@ -50,7 +54,7 @@ jobs:
       - run: echo "${GITHUB_DEVOPS_PRIVATE_SSH_KEY_BASE64}" | base64 --decode | ssh-add - > /dev/null
       - restore_cache:
           key: v1-{{ checksum "poetry.lock" }}
-      - run: make ci_setup
+      - run: make dependencies
       - run: poetry run python devops.py deploy
 
 workflows:
@@ -59,7 +63,7 @@ workflows:
     jobs:
       - test
       - lint
-      - check_changelog:
+      - check_commits:
           filters:
             branches:
               ignore: master

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -1,6 +1,0 @@
-repos:
--   repo: https://github.com/ambv/black
-    rev: 21.5b1
-    hooks:
-    - id: black
-      language_version: python3.6

--- a/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.repo_name}}/CONTRIBUTING.rst
@@ -14,24 +14,53 @@ Set up your development environment with::
     cd {{cookiecutter.repo_name}}
     make setup
 
-``make setup`` will setup python managed by
-`pyenv <https://github.com/yyuu/pyenv>`_ and install dependencies using
-`poetry <https://poetry.eustace.io/>`_.
+``make setup`` will set up a development environment managed by Docker.
+Install docker `here <https://www.docker.com/get-started>`_ and be sure
+it is running when executing any of the commands below.
 
 Testing and Validation
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Run the tests with::
+Run the tests on one Python version with::
 
     make test
+
+Run the full test suite against all supported Python versions with::
+
+    make full-test-suite
 
 Validate the code with::
 
     make lint
 
-Run automated code formatting with::
+If your code fails the ``black`` check, automatically format your code with::
 
     make format
+
+Committing
+~~~~~~~~~~
+
+This project uses `git-tidy <https://github.com/Opus10/git-tidy>`_ to produce structured
+commits with git trailers. Information from commit messages is used to generate release
+notes and bump the version properly.
+
+To do a structured commit with ``git-tidy``, do::
+
+    make tidy-commit
+
+All commits in a pull request must be tidy commits that encapsulate a
+change. Ideally entire features or bug fixes are encapsulated in a
+single commit. Squash all of your commits into a tidy commit with::
+
+    make tidy-squash
+
+To check if your commits pass linting, do::
+
+    make tidy-lint
+
+Note, the above command lints every commit since branching from master.
+You can also run ``make shell`` and run ``git tidy`` commands inside
+the docker environment to do other flavors of ``git tidy`` commands.
 
 Documentation
 ~~~~~~~~~~~~~
@@ -43,7 +72,7 @@ Documentation
 The static HTML files are stored in the ``docs/_build/html`` directory.
 A shortcut for opening them (on OSX) is::
 
-    make open_docs
+    make open-docs
 
 Releases and Versioning
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/{{cookiecutter.repo_name}}/LICENSE
+++ b/{{cookiecutter.repo_name}}/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021, Opus 10
+Copyright (c) 2022, Opus 10
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -2,17 +2,16 @@
 #
 # This Makefile has the following targets:
 #
-# package_managers - Sets up python managers and python package managers
-# clean_env - Removes the virtuale env
-# dependencies - Installs all dependencies for a project
-# setup - Sets up the entire development environment and installs dependencies
-# clean_docs - Clean the documentation folder
-# clean - Clean any generated files (including documentation)
-# open_docs - Open any docs generated with "make docs"
+# setup - Sets up the development environment
+# dependencies - Installs dependencies
+# clean-docs - Clean the documentation folder
+# open-docs - Open any docs generated with "make docs"
 # docs - Generated sphinx docs
 # lint - Run code linting and static checks
 # format - Format code using black
 # test - Run tests using pytest
+# full-test-suite - Run full test suite using tox
+# shell - Run a shell in a virtualenv
 
 OS = $(shell uname -s)
 
@@ -20,98 +19,65 @@ PACKAGE_NAME={{cookiecutter.repo_name}}
 MODULE_NAME={{cookiecutter.module_name}}
 SHELL=bash
 
-PY36_VERSION=3.6.13
-PY37_VERSION=3.7.10
-PY38_VERSION=3.8.10
-PY39_VERSION=3.9.4
+# Only mount the git config file when it exists. Otherwise Docker will create an empty directory
+ifneq ($(wildcard ~/.gitconfig),) 
+    GIT_CONFIG_DOCKER_MOUNT = -v ~/.gitconfig:/root/.gitconfig
+endif 
+
+# Docker run mounts the local code directory, SSH (for git), and global git config information
+MAKE_CMD_WRAPPER?=docker run --rm -v $(shell pwd):/code -v ~/.ssh:/home/circleci/.ssh $(GIT_CONFIG_DOCKER_MOUNT) -it opus10/circleci-public-python-library
 
 
 # Print usage of main targets when user types "make" or "make help"
+.PHONY: help
 help:
 	@echo "Please choose one of the following targets: \n"\
-	      "    setup: Setup development environment and install dependencies\n"\
+	      "    setup: Setup development environment\n"\
+	      "    dependencies: Install dependencies\n"\
 	      "    test: Run tests\n"\
+	      "    tox: Run tests against all versions of Python\n"\
 	      "    lint: Run code linting and static checks\n"\
 	      "    docs: Build Sphinx documentation\n"\
-	      "    open_docs: Open built documentation\n"\
+	      "    open-docs: Open built documentation\n"\
 	      "\n"\
 	      "View the Makefile for more documentation"
 	@exit 2
 
 
-# Utility to verify we arent in a virtualenv
-.PHONY: check_not_inside_venv
-check_not_inside_venv:
-ifeq (${OS}, Darwin)
-	which pip | grep -q ".pyenv" || (echo "Please deactivate your virtualenv and try again" && exit 1)
-endif
-
-
-# Sets up pyenv, poetry, and any other package/language managers (e.g. NPM)
-.PHONY: package_managers
-package_managers: check_not_inside_venv
-ifeq (${OS}, Darwin)
-# Install pyenv and ensure we remain up to date with pyenv so that new python
-# versions are available for installation
-	-brew install pyenv 2> /dev/null
-	-brew upgrade pyenv 2> /dev/null
-	-pyenv rehash
-	pyenv install -s --patch ${PY36_VERSION} < <(curl -sSL https://github.com/python/cpython/commit/8ea6353.patch)
-	pyenv install -s --patch ${PY37_VERSION}
-	pyenv install -s --patch ${PY38_VERSION}
-	pyenv install -s --patch ${PY39_VERSION}
-	pyenv local ${PY36_VERSION} ${PY37_VERSION} ${PY38_VERSION} ${PY39_VERSION}
-endif
-# Conditionally install pipx so that we can globally install poetry
-	pip install --user --upgrade --force-reinstall pipx
-	pipx ensurepath
-	-pipx install --force poetry --pip-args="--upgrade"
-
-
 # Builds all dependencies for a project
 .PHONY: dependencies
 dependencies:
-	poetry install
+	$(MAKE_CMD_WRAPPER) poetry install
 
 
-.PHONY: git_tidy
-git_tidy:
-	-pipx install --force git-tidy --pip-args="--upgrade"
-	git tidy --template -o .gitcommit.tpl
-	git config --local commit.template .gitcommit.tpl
-
-
-.PHONY: pre_commit
-pre_commit:
-	poetry run pre-commit install
-
-
-.PHONY: ci_setup
-ci_setup: package_managers git_tidy dependencies
-
-
-# Sets up environment and installs dependencies
+# Sets up development environment
 .PHONY: setup
-setup: check_not_inside_venv package_managers git_tidy dependencies pre_commit
+setup: dependencies
+	$(MAKE_CMD_WRAPPER) poetry run git-tidy --template -o .gitcommit.tpl
+	$(MAKE_CMD_WRAPPER) poetry run git config --local commit.template .gitcommit.tpl
+
+
+# Run pytest
+.PHONY: test
+test:
+	$(MAKE_CMD_WRAPPER) poetry run pytest
+
+
+# Run full test suite
+.PHONY: full-test-suite
+full-test-suite:
+	$(MAKE_CMD_WRAPPER) poetry run tox
 
 
 # Clean the documentation folder
-.PHONY: clean_docs
-clean_docs:
-	-cd docs && poetry run make clean
-
-
-# Clean any auto-generated files
-.PHONY: clean
-clean: clean_docs clean_env
-	rm -rf dist/*
-	rm -rf coverage .coverage .coverage*
-	rm -rf .venv
+.PHONY: clean-docs
+clean-docs:
+	-$(MAKE_CMD_WRAPPER) poetry run bash -c 'cd docs && make clean'
 
 
 # Open the build docs (only works on Mac)
-.PHONY: open_docs
-open_docs:
+.PHONY: open-docs
+open-docs:
 ifeq (${OS}, Darwin)
 	open docs/_build/html/index.html
 else
@@ -121,44 +87,38 @@ endif
 
 # Build Sphinx autodocs
 .PHONY: docs
-docs: clean_docs  # Ensure docs are clean, otherwise weird render errors can result
-	cd docs && poetry run make html
+docs: clean-docs  # Ensure docs are clean, otherwise weird render errors can result
+	$(MAKE_CMD_WRAPPER) poetry run bash -c 'cd docs && make html'
 
 
-# Run code linting and static analysis
+# Run code linting and static analysis. Ensure docs can be built
 .PHONY: lint
 lint:
-	poetry run black . --check
-	poetry run flake8 -v ${MODULE_NAME}/
-	poetry run temple update --check
-	poetry run make docs  # Ensure docs can be built during validation
+	$(MAKE_CMD_WRAPPER) poetry run black . --check
+	$(MAKE_CMD_WRAPPER) poetry run flake8 -v ${MODULE_NAME}
+	$(MAKE_CMD_WRAPPER) poetry run temple update --check
+	$(MAKE_CMD_WRAPPER) poetry run bash -c 'cd docs && make html'
 
 
-# Lint commit messages and show changelog when on circleci
-check_changelog:
-ifdef CIRCLECI
-	git tidy-log origin/master..
-endif
-	git tidy-lint origin/master
+# Lint commit messages
+.PHONY: tidy-lint
+tidy-lint:
+	$(MAKE_CMD_WRAPPER) poetry run git tidy-lint origin/master..
 
 
-# Format code
+# Perform a tidy commit
+.PHONY: tidy-commit
+tidy-commit:
+	$(MAKE_CMD_WRAPPER) poetry run git tidy-commit
+
+
+# Perform a tidy squash
+.PHONY: tidy-squash
+tidy-squash:
+	$(MAKE_CMD_WRAPPER) poetry run git tidy-squash origin/master
+
+
+# Format code with black
+.PHONY: format
 format:
-	poetry run black .
-
-
-# Run tests
-.PHONY: test
-test:
-	poetry run tox
-
-
-# Show the version and name of the project
-.PHONY: version
-version:
-	-@poetry version | rev | cut -f 1 -d' ' | rev
-
-
-.PHONY: project_name
-project_name:
-	-@poetry version | cut -d' ' -f1
+	$(MAKE_CMD_WRAPPER) poetry run black .

--- a/{{cookiecutter.repo_name}}/devops.py
+++ b/{{cookiecutter.repo_name}}/devops.py
@@ -98,7 +98,7 @@ def _find_sem_ver_update():
 def _update_package_version():
     """Apply semantic versioning to package based on git commit messages"""
     # Obtain the current version
-    old_version = _shell_stdout('make version')
+    old_version = _shell_stdout("poetry version | rev | cut -f 1 -d' ' | rev")
     if old_version == '0.0.0':
         old_version = ''
     latest_tag = _find_latest_tag()
@@ -114,7 +114,7 @@ def _update_package_version():
     _shell(f'poetry version {sem_ver}')
 
     # Get the new version
-    new_version = _shell_stdout('make version')
+    new_version = _shell_stdout("poetry version | rev | cut -f 1 -d' ' | rev")
 
     if new_version == old_version:
         raise RuntimeError(

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -68,7 +68,7 @@ default_role = 'any'
 
 # General information about the project.
 project = u'{{cookiecutter.repo_name}}'
-copyright = u'2021, Opus 10'
+copyright = u'2022, Opus 10'
 author = u'Opus 10 Engineering'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.black]
 line-length = 79
-target-version = ['py36']
+target-version = ['py37']
 skip-string-normalization = true
 
 [tool.poetry]
@@ -19,10 +19,10 @@ classifiers = [
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3 :: Only",
 ]
 license = "BSD-3-Clause"
@@ -32,23 +32,19 @@ repository = "https://github.com/Opus10/{{cookiecutter.repo_name}}"
 documentation = "https://{{cookiecutter.repo_name}}.readthedocs.io"
 
 [tool.poetry.dependencies]
-python = ">=3.6.2,<4"
+python = ">=3.7.0,<4"
 
 [tool.poetry.dev-dependencies]
-black = "21.5b1"
+black = "22.1.0"
 flake8 = "3.9.2"
-flake8-bugbear = "21.4.3"
-flake8-comprehensions = "3.5.0"
+flake8-bugbear = "22.1.11"
+flake8-comprehensions = "3.8.0"
 flake8-import-order = "0.18.1"
 flake8-logging-format = "0.6.0"
 flake8-mutable = "1.2.0"
-packaging = "19.2"
-pip = "*"
-pre-commit = "2.13.0"
-pytest = "6.2.4"
-pytest-cov = "2.12.0"
-requests = "2.25.1"
-Sphinx = "4.0.2"
-sphinx-rtd-theme = "0.5.2"
+pytest = "6.2.5"
+pytest-cov = "3.0.0"
+Sphinx = "4.4.0"
+sphinx-rtd-theme = "1.0.0"
 temple = "*"
-tox = "3.23.1"
+tox = "3.24.5"

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = clean,py{36,37,38,39},report
+envlist = clean,py{37,38,39,310},report
 
 [testenv]
 whitelist_externals =


### PR DESCRIPTION
Major updates include:
- Dropping of python3.6 support. Added python3.10 support
- Upgrades several default development dependencies
- Completely refactors Makefile to use Docker instead of a native Mac setup
- Other trivial doc changes based on the year changing and local dev setup changing

@tomage just a heads up that I have tested out these changes via git-tidy's `docker` branch. They should be good to go live for all of our python libraries!